### PR TITLE
Update Ferdi from the ferdi repo instead of the official franz repo

### DIFF
--- a/src/dev-app-update.yml
+++ b/src/dev-app-update.yml
@@ -1,3 +1,3 @@
-owner: meetfranz
-repo: franz
+owner: kytwb
+repo: ferdi
 provider: github


### PR DESCRIPTION
This change should help make Ferdi update using the repository on `https://github.com/kytwb/ferdi` instead of `https://github.com/meetfranz/franz`.


